### PR TITLE
Update URL to gpt4all-chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gpt4all-nix
 
-A Nix flake for gpt4all chat client: https://github.com/nomic-ai/gpt4all-chat
+A Nix flake for gpt4all chat client: https://github.com/nomic-ai/gpt4all/tree/main/gpt4all-chat
 
 ## Running
 


### PR DESCRIPTION

The original repo states that:

  This repository has been archived by the owner on May 10, 2023. It is now read-only.

and leaves a pointer to the current home for the project.